### PR TITLE
[DSCT-68] GitHub PR 8주차

### DIFF
--- a/NaK/NaK_week14/BOJ_16401.py
+++ b/NaK/NaK_week14/BOJ_16401.py
@@ -1,0 +1,36 @@
+# 모든 조카가 과자를 받도록 할 수 있는 최대 길이 구하기
+# 이걸 이진탐색으로 어케 나눔?
+
+# start = 1 (가장 짧은 가능한 길이), end = max(cookie) (가장 긴 과자의 길이)
+# mid 길이로 잘랐을 때 나오는 조각 수 합: count
+# 조각 수(count)와 조카 수 비교
+# mid 길이로 자르면 조각 수가 조카 수보다 많거나 딱 맞음
+# -> 길이 늘릴 수 있음 (start = mid + 1)
+# mid 길이로 자르면 조각 수가 조카 수를 못 채움
+# -> 길이 줄이기 (end = mid -1)
+
+
+M, N = map(int, input().split())
+cookie = list(map(int, input().split()))
+
+start = 1
+end = max(cookie)
+result = 0
+
+while start <= end:
+    mid = (start + end) // 2
+    count = sum(c // mid for c in cookie)
+
+    if count >= M:
+        result = mid
+        start = mid + 1
+    else:
+        end = mid - 1
+
+print(result)
+
+
+# 다른 사람의 플로우를 참고하여 코드 작성해보았다.
+# 이번에는 코드가 진행하는 과정을 노트에 적어가며 직접 계산 했는데 이해가 잘 되고 풀이도 쉽게 되었다.
+# 앞으로 이런 방식으로 코드 풀이를 하면 좋을 것 같다.
+# https://velog.io/@kmh9250/%EB%B0%B1%EC%A4%8016401-%EA%B3%BC%EC%9E%90-%EB%82%98%EB%88%A0%EC%A3%BC%EA%B8%B0

--- a/NaK/NaK_week14/BOJ_2343.py
+++ b/NaK/NaK_week14/BOJ_2343.py
@@ -1,0 +1,34 @@
+# 강의 수: N, 블루레이 수: M
+# start = max(guitar) (입력받은 배열의 최대값), end = sum(guitar) (입력받은 배열의 총합)
+# count: mid의 길이로 배열을 담을 때 필요한 블루레이수
+# mid로 자른 강의 수(cnt)와 블루레이 수(M) 비교
+#  cnt가 M보다 많거나 같음
+# -> 길이 늘릴 수 있음 (start = mid + 1)
+# cnt가 M을 못 채움
+# -> 길이 줄이기 (end = mid - 1)
+
+N,M = map(int, input().split())
+guitar = list(map(int, input().split()))
+
+start,end = max(guitar), sum(guitar)
+result = 0
+
+while start <= end:
+    mid = (start + end) // 2
+
+    total = 0
+    count = 1
+    for i in guitar:
+        if total + i > mid:
+            count += 1
+            total = 0
+        total += i
+
+    if count > M:
+        start = mid + 1
+
+    else:
+        end = mid - 1
+        result = mid
+
+print(result)


### PR DESCRIPTION
# 1. 과자 나눠주기
### 📍플로우
- 모든 조카가 과자를 받도록 할 수 있는 최대 길이 구하기
- start = 1 (가장 짧은 가능한 길이), end = max(cookie) (가장 긴 과자의 길이)
- mid 길이로 잘랐을 때 나오는 조각 수 합: count
- 조각 수(count)와 조카 수 비교
- mid 길이로 자르면 조각 수가 조카 수보다 많거나 딱 맞음
-> 길이 늘릴 수 있음 (start = mid + 1)
- mid 길이로 자르면 조각 수가 조카 수를 못 채움
-> 길이 줄이기 (end = mid -1)

### 📍코드
```
M, N = map(int, input().split())
cookie = list(map(int, input().split()))

start = 1
end = max(cookie)
result = 0

while start <= end:
    mid = (start + end) // 2
    count = sum(c // mid for c in cookie)

    if count >= M:
        result = mid
        start = mid + 1
    else:
        end = mid - 1

print(result)
```

### 📍느낀점
다른 사람의 플로우를 참고하여 코드 작성해보았다. 이번에는 코드가 진행하는 과정을 노트에 적어가며 직접 계산 했는데 이해가 잘 되고 풀이도 쉽게 되었다. 앞으로 이런 방식으로 코드 풀이를 하면 좋을 것 같다.

[플로우 참고용 링크 첨부](https://velog.io/@kmh9250/%EB%B0%B1%EC%A4%8016401-%EA%B3%BC%EC%9E%90-%EB%82%98%EB%88%A0%EC%A3%BC%EA%B8%B0)


# 2. 기타 레슨
### 📍플로우
- 강의 수: N, 블루레이 수: M
- start = max(guitar) (입력받은 배열의 최대값), end = sum(guitar) (입력받은 배열의 총합)
-  count: mid의 길이로 배열을 담을 때 필요한 블루레이수
- mid로 자른 강의 수(cnt)와 블루레이 수(M) 비교
-  cnt가 M보다 많거나 같음
-> 길이 늘릴 수 있음 (start = mid + 1)
- cnt가 M을 못 채움
-> 길이 줄이기 (end = mid - 1)

### 📍코드
```
N,M = map(int, input().split())
guitar = list(map(int, input().split()))

start,end = max(guitar), sum(guitar)
result = 0

while start <= end:
    mid = (start + end) // 2

    total = 0
    count = 1
    for i in guitar:
        if total + i > mid:
            count += 1
            total = 0
        total += i

    if count > M:
        start = mid + 1

    else:
        end = mid - 1
        result = mid

print(result)
```

### 📍느낀점
이번 코드를 푸는 과정에도 코드 한줄 한줄이 어떤 결과를 낳는지 직접 작성하면서 진행하였다. 점점 풀이가 헷갈리고 어려워질수록 이렇게 직접 작성하면서 코드 작성하는 것이 좋다고 느껴졌다.
그리고 이번에 이진탐색을 코드로 작성하는 것을 완벽히까진 아니지만 어느정도 이해가 되었기 때문에 다음에 이진탐색 문제가 나와도 잘 풀 수 있을 것 같다. 다만, 어떤 문제가 이진탐색을 필요로 하는지에 대한 것은 연습이 더 필요할 것 같다.